### PR TITLE
WEBC-1626 - add eventDispatcher to the player types 

### DIFF
--- a/packages/common/global-types/kaltura-player/player.d.ts
+++ b/packages/common/global-types/kaltura-player/player.d.ts
@@ -5,11 +5,9 @@ type CoreEventListener = (event: FakeEvent) => boolean | void;
 declare namespace KalturaPlayerTypes {
     export interface Player {
         pause(): void;
-
         play(): void;
-
+        dispatchEvent(event: FakeEvent): boolean;
         addEventListener(type: string, listener: CoreEventListener): void;
-
         removeEventListener: (type: string, listener: CoreEventListener) => void;
         Event: Record<string, string>;
         currentTime: number;


### PR DESCRIPTION
We need access to the event dispatcher of the player. This adds it to the player type 