### PR TITLE
chore: fix css dashed class names errors using

### DIFF
--- a/packages/linkify/webpack.config.js
+++ b/packages/linkify/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = (env, options) => {
             {
               loader: 'css-loader',
               options: {
+                localsConvention: 'camelCase',
                 modules: {
                   localIdentName: 'contrib[name]__[local]___[hash:base64:5]'
                 }

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = (env, options) => {
             {
               loader: 'css-loader',
               options: {
+                localsConvention: 'camelCase',
                 modules: {
                   localIdentName: 'contrib[name]__[local]___[hash:base64:5]'
                 },


### PR DESCRIPTION
Add localsConvention: 'camelCase' property to css-loader options