### PR TITLE
FEV-797 -  Player V7| |Navigation 2.1.0| - UI - 'Full Screen' tooltip is cutoff by the kitchen sink

### DIFF
--- a/packages/ui/src/components/kitchen-sink/_kitchen-sink.scss
+++ b/packages/ui/src/components/kitchen-sink/_kitchen-sink.scss
@@ -7,11 +7,11 @@
   height: 100%;
   transition: opacity 500ms ease-in-out;
   opacity: 0;
-  z-index: 0;
+  z-index: -1;
 
   &.active {
     opacity: 1;
-    z-index: 1;
+    z-index: 0;
   }
 }
 


### PR DESCRIPTION
Fix z-index of active\inactive kitchen-sink

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/playkit-js-contrib/335)
<!-- Reviewable:end -->
