### PR TITLE
fix(FEV-665): hide oversized text in banner

### DIFF
--- a/packages/ui/src/components/banner/_banner.scss
+++ b/packages/ui/src/components/banner/_banner.scss
@@ -38,6 +38,7 @@
 .bannerBody {
   height: 100%;
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .title {


### PR DESCRIPTION
fix styles for banner component
<img width="590" alt="Screen Shot 2021-04-17 at 12 21 19 AM" src="https://user-images.githubusercontent.com/51074448/115085257-de231180-9f12-11eb-95b9-31a2b980dfd9.png">
