### PR TITLE
fix(fev-803): change classname for upper-bar icon cause of font-awesome use same classname

### DIFF
--- a/packages/ui/src/components/upper-bar/_upper-bar.scss
+++ b/packages/ui/src/components/upper-bar/_upper-bar.scss
@@ -1,5 +1,5 @@
 .root {
-  :global(.icon--clickable) {
+  :global(.upper-bar-icon) {
     cursor: pointer;
   }
 

--- a/packages/ui/src/upper-bar-item.tsx
+++ b/packages/ui/src/upper-bar-item.tsx
@@ -36,7 +36,7 @@ export class UpperBarItem {
     const children = renderItem(props);
 
     return (
-      <div onClick={onClick} className={'icon--clickable'}>
+      <div onClick={onClick} className={'upper-bar-icon'}>
         {children}
       </div>
     );


### PR DESCRIPTION
Use unic classname for upper-bar icons to avoid conflicts with font-awesome
<img width="280" alt="Screen Shot 2021-04-22 at 5 12 54 PM" src="https://user-images.githubusercontent.com/51074448/115729455-18b30100-a38e-11eb-9374-88bb6ad77aa1.png">
