### PR TITLE
fix(fev-964): use redux value to define player size

### DIFF
--- a/packages/common/global-types/kaltura-player/kaltura-player.d.ts
+++ b/packages/common/global-types/kaltura-player/kaltura-player.d.ts
@@ -16,6 +16,14 @@ declare global {
       components: {
         withPlayer: any;
         Tooltip: any;
+        PLAYER_SIZE: {
+          EXTRA_LARGE: 'extralarge';
+          EXTRA_SMALL: 'extrasmall';
+          LARGE: 'large';
+          MEDIUM: 'medium';
+          SMALL: 'small';
+          TINY: 'tiny';
+        };
       };
       preactHooks: any;
       preacti18n: any;

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -11,7 +11,7 @@ type ManagedComponentState = {
 };
 type ManagedComponentProps = {
   isShown: () => boolean;
-  renderChildren: (palyerSize: string) => ComponentChildren;
+  renderChildren: (playerSize: string) => ComponentChildren;
   label: string;
   fillContainer: boolean;
   playerSize?: string;

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -40,31 +40,12 @@ export class ManagedComponent extends Component<
     });
   }
 
-  shouldComponentUpdate(
-    prevProps: Readonly<ManagedComponentProps>,
-    prevState: Readonly<ManagedComponentState>
-  ): boolean {
-    const {toggler} = this.state;
-    const {
-      isShown,
-      renderChildren,
-      label,
-      fillContainer,
-      updateOnPlayerSizeChanged,
-      playerSize,
-    } = this.props;
-    if (
-      prevState.toggler !== toggler ||
-      prevProps.isShown !== isShown ||
-      prevProps.renderChildren !== renderChildren ||
-      prevProps.label !== label ||
-      prevProps.fillContainer !== fillContainer ||
-      prevProps.updateOnPlayerSizeChanged !== updateOnPlayerSizeChanged ||
-      (updateOnPlayerSizeChanged && prevProps.playerSize !== playerSize)
-    ) {
-      return true;
-    }
-    return false;
+  shouldComponentUpdate(prevProps: Readonly<ManagedComponentProps>): boolean {
+    const {updateOnPlayerSizeChanged, playerSize} = this.props;
+    return (
+      (updateOnPlayerSizeChanged && prevProps.playerSize !== playerSize) ||
+      prevProps.playerSize === playerSize
+    );
   }
 
   componentDidMount(): void {

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -2,17 +2,26 @@ import {h, Component, ComponentChild, ComponentChildren} from 'preact';
 import {getContribLogger} from '@playkit-js-contrib/common';
 import {ContribLogger} from '@playkit-js-contrib/common';
 import * as styles from './_managed-component.scss';
+const {
+  redux: {connect},
+} = KalturaPlayer.ui;
 
 type ManagedComponentState = {
   toggler: boolean;
 };
 type ManagedComponentProps = {
   isShown: () => boolean;
-  renderChildren: () => ComponentChildren;
+  renderChildren: (palyerSize: string) => ComponentChildren;
   label: string;
   fillContainer: boolean;
+  playerSize?: string;
+  updateOnPlayerSizeChanged?: boolean;
 };
 
+const mapStateToProps = (state: Record<string, any>) => ({
+  playerSize: state.shell.playerSize,
+});
+@connect(mapStateToProps, null, null, {forwardRef: true})
 export class ManagedComponent extends Component<
   ManagedComponentProps,
   ManagedComponentState
@@ -31,6 +40,16 @@ export class ManagedComponent extends Component<
     });
   }
 
+  shouldComponentUpdate(prevProps: Readonly<ManagedComponentProps>): boolean {
+    if (
+      prevProps.playerSize !== this.props.playerSize &&
+      !this.props.updateOnPlayerSizeChanged
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   componentDidMount(): void {
     this._logger = getContribLogger({
       module: 'contrib-ui',
@@ -46,7 +65,7 @@ export class ManagedComponent extends Component<
   }
 
   render() {
-    const {fillContainer, isShown} = this.props;
+    const {fillContainer, isShown, playerSize} = this.props;
     if (!isShown()) {
       return null;
     }
@@ -61,7 +80,7 @@ export class ManagedComponent extends Component<
       <div
         data-contrib-item={this.props.label}
         className={fillContainer ? styles.fillContainer : ''}>
-        {this.props.renderChildren()}
+        {this.props.renderChildren(playerSize)}
       </div>
     );
   }

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -40,14 +40,31 @@ export class ManagedComponent extends Component<
     });
   }
 
-  shouldComponentUpdate(prevProps: Readonly<ManagedComponentProps>): boolean {
+  shouldComponentUpdate(
+    prevProps: Readonly<ManagedComponentProps>,
+    prevState: Readonly<ManagedComponentState>
+  ): boolean {
+    const {toggler} = this.state;
+    const {
+      isShown,
+      renderChildren,
+      label,
+      fillContainer,
+      updateOnPlayerSizeChanged,
+      playerSize,
+    } = this.props;
     if (
-      prevProps.playerSize !== this.props.playerSize &&
-      !this.props.updateOnPlayerSizeChanged
+      prevState.toggler !== toggler ||
+      prevProps.isShown !== isShown ||
+      prevProps.renderChildren !== renderChildren ||
+      prevProps.label !== label ||
+      prevProps.fillContainer !== fillContainer ||
+      prevProps.updateOnPlayerSizeChanged !== updateOnPlayerSizeChanged ||
+      (updateOnPlayerSizeChanged && prevProps.playerSize !== playerSize)
     ) {
-      return false;
+      return true;
     }
-    return true;
+    return false;
   }
 
   componentDidMount(): void {


### PR DESCRIPTION
Current PR fixes issue with top-bar icons when layouts changed in dual-screen plugin:
pip - pip-inverse
pipMinimized - pipMinimized-inverse
property `kalturaPlayer.dimensions` returns width value of inverted layout instead of main one that causes an issue since contrib upper-bar manager doesn't render plugin icons for tiny width of player.