### PR TITLE
fix(FEV-1137): hotspot isn't shown in safari

### DIFF
--- a/packages/ui/src/player-utils.ts
+++ b/packages/ui/src/player-utils.ts
@@ -16,6 +16,7 @@ export function getVideoSize(
   const videoTrack = kalturaPlayer.getActiveTracks().video;
 
   if (!videoTrack) {
+    // fallback - mainly for Safari
     if (kalturaPlayer.getVideoElement()){
       return {
         width: kalturaPlayer.getVideoElement().videoWidth,

--- a/packages/ui/src/player-utils.ts
+++ b/packages/ui/src/player-utils.ts
@@ -13,14 +13,20 @@ export function getVideoSize(
     return {width: 0, height: 0};
   }
 
-  const videoElement = kalturaPlayer.getVideoElement();
+  const videoTrack = kalturaPlayer.getActiveTracks().video;
 
-  if (!videoElement) {
+  if (!videoTrack) {
+    if (kalturaPlayer.getVideoElement()){
+      return {
+        width: kalturaPlayer.getVideoElement().videoWidth,
+        height: kalturaPlayer.getVideoElement().videoHeight
+      }
+    }
     return {width: 0, height: 0};
   }
 
   return {
-    width: videoElement.videoWidth,
-    height: videoElement.videoHeight,
+    width: videoTrack.width,
+    height: videoTrack.height,
   };
 }

--- a/packages/ui/src/player-utils.ts
+++ b/packages/ui/src/player-utils.ts
@@ -13,14 +13,14 @@ export function getVideoSize(
     return {width: 0, height: 0};
   }
 
-  const videoTrack = kalturaPlayer.getActiveTracks().video;
+  const videoElement = kalturaPlayer.getVideoElement();
 
-  if (!videoTrack) {
+  if (!videoElement) {
     return {width: 0, height: 0};
   }
 
   return {
-    width: videoTrack.width,
-    height: videoTrack.height,
+    width: videoElement.videoWidth,
+    height: videoElement.videoHeight,
   };
 }


### PR DESCRIPTION
getVideoSize used video inside active tracks to get the video dimensions.
I have no idea why and why it is not working in Safari
But we can just use the getVideoElement instead

solves FEV-1137