### PR TITLE
fix(FEV-1137): hotspot isn't shown in safari

### DIFF
--- a/packages/ui/src/floating-manager.tsx
+++ b/packages/ui/src/floating-manager.tsx
@@ -199,6 +199,11 @@ export class FloatingManager {
       this._updateComponents();
     });
 
+    kalturaPlayer.addEventListener(kalturaPlayer.Event.LOADED_DATA, () => {
+      this._updateCachedCanvas();
+      this._updateComponents();
+    });
+
     this._options.presetManager.on(
       PresetManagerEventTypes.VideoResizeEvent,
       () => {


### PR DESCRIPTION
Needed to add another "_updateCachedCanvas" call in floating manager as the video element doesn't have the videoWidth till LOADED_DATA event