### PR TITLE
fix(FEV-1137): hotspot isn't shown in safari

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   "rules": {
     "header-max-length": [2, "always", 150],
-    "type-case": [0],
+    "scope-case": [0],
   }
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   "rules": {
-    "header-max-length": [2, "always", 150]
+    "header-max-length": [2, "always", 150],
+    "type-case": [0],
   }
 };

--- a/packages/ui/src/player-utils.ts
+++ b/packages/ui/src/player-utils.ts
@@ -15,7 +15,11 @@ export function getVideoSize(
 
   const videoTrack = kalturaPlayer.getActiveTracks().video;
 
-  if (!videoTrack) {
+  if (
+    !videoTrack ||
+    videoTrack.width === undefined ||
+    videoTrack.height === undefined
+  ) {
     // fallback - mainly for Safari
     if (kalturaPlayer.getVideoElement()) {
       return {


### PR DESCRIPTION
In Safari we do get the video property from the active tracks but the width / height is undefined

solves FEV-1137