### PR TITLE
fix(FEV-413): i as Kaltura want to define the order in which the plugins are shown on the player

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,7 +4,7 @@ module.exports = {
   singleQuote: true,
   jsxBracketSameLine: true,
   trailingComma: 'es5',
-  printWidth: 80,
+  printWidth: 120,
   arrowParens: 'avoid',
   endOfLine: 'auto',
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,7 +4,7 @@ module.exports = {
   singleQuote: true,
   jsxBracketSameLine: true,
   trailingComma: 'es5',
-  printWidth: 120,
+  printWidth: 80,
   arrowParens: 'avoid',
   endOfLine: 'auto',
 };

--- a/packages/ui/src/components/managed-component/_managed-component.scss
+++ b/packages/ui/src/components/managed-component/_managed-component.scss
@@ -2,3 +2,7 @@
   width: 100%;
   height: 100%;
 }
+
+.inline-container {
+  display: inline-block;
+}

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -1,4 +1,10 @@
-import {h, Component, ComponentChild, ComponentChildren} from 'preact';
+import {
+  h,
+  Component,
+  ComponentChild,
+  ComponentChildren,
+  Fragment,
+} from 'preact';
 import {getContribLogger} from '@playkit-js-contrib/common';
 import {ContribLogger} from '@playkit-js-contrib/common';
 import * as styles from './_managed-component.scss';
@@ -77,7 +83,10 @@ export class ManagedComponent extends Component<
     return (
       <div
         data-contrib-item={this.props.label}
-        className={fillContainer ? styles.fillContainer : ''}>
+        className={[
+          `${fillContainer ? styles.fillContainer : ''}`,
+          styles.inlineContainer,
+        ].join(' ')}>
         {this.props.renderChildren(playerSize)}
       </div>
     );

--- a/packages/ui/src/components/managed-component/managed-component.tsx
+++ b/packages/ui/src/components/managed-component/managed-component.tsx
@@ -1,10 +1,4 @@
-import {
-  h,
-  Component,
-  ComponentChild,
-  ComponentChildren,
-  Fragment,
-} from 'preact';
+import {h, Component, ComponentChild, ComponentChildren} from 'preact';
 import {getContribLogger} from '@playkit-js-contrib/common';
 import {ContribLogger} from '@playkit-js-contrib/common';
 import * as styles from './_managed-component.scss';

--- a/packages/ui/src/components/upper-bar/_upper-bar.scss
+++ b/packages/ui/src/components/upper-bar/_upper-bar.scss
@@ -3,7 +3,7 @@
     cursor: pointer;
   }
 
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
 
   &>* {

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -10,7 +10,7 @@ import UpperBarConfig = KalturaPlayerContribTypes.UpperBarConfig;
 import {getContribConfig} from './contrib-utils';
 import {IconsMenu} from './components/icons-menu';
 
-const DefaultPluginOrder = {
+const DefaultPluginOrder: {[pluginName: string]: number} = {
   Navigation: 10,
   'Q&A': 20,
   Moderation: 30,
@@ -132,7 +132,7 @@ export class UpperBarManager {
     //       }
     //     }
     // };
-    const undefinedPluginDefaultOrder = Math.max(...Object.values(DefaultPluginOrder)) + 10;
+    const undefinedPluginDefaultOrder: number = Math.max(...Object.values(DefaultPluginOrder)) + 10;
     const itemOptions = {
       kalturaPlayer: this._options.kalturaPlayer,
       data,

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -62,10 +62,19 @@ export class UpperBarManager {
   constructor(options: UpperBarManagerOptions) {
     this._options = options;
 
-    this._upperBarConfig = getContribConfig(this._options.kalturaPlayer, 'ui.upperBar', defaultUpperBarConfig, {
-      explicitMerge: ['presetAreasMapping'],
-    });
-    this._iconsMenuConfig = getContribConfig(this._options.kalturaPlayer, 'ui.iconsMenu', {iconsOrder: {}});
+    this._upperBarConfig = getContribConfig(
+      this._options.kalturaPlayer,
+      'ui.upperBar',
+      defaultUpperBarConfig,
+      {
+        explicitMerge: ['presetAreasMapping'],
+      }
+    );
+    this._iconsMenuConfig = getContribConfig(
+      this._options.kalturaPlayer,
+      'ui.iconsMenu',
+      {iconsOrder: {}}
+    );
 
     const groupedPresets = PresetsUtils.groupPresetAreasByType({
       presetAreasMapping: this._upperBarConfig.presetAreasMapping,
@@ -92,7 +101,9 @@ export class UpperBarManager {
   };
 
   private _renderItems = (playerSize: string) => {
-    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(playerSize);
+    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(
+      playerSize
+    );
 
     const isIconMenuVisible = !!(upperBarItems.length && iconMenuItems.length);
 
@@ -132,7 +143,8 @@ export class UpperBarManager {
     //       }
     //     }
     // };
-    const undefinedPluginDefaultOrder: number = Math.max(...Object.values(DefaultPluginOrder)) + 10;
+    const undefinedPluginDefaultOrder: number =
+      Math.max(...Object.values(DefaultPluginOrder)) + 10;
     const itemOptions = {
       kalturaPlayer: this._options.kalturaPlayer,
       data,

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -9,6 +9,23 @@ import {PresetsUtils} from './presets-utils';
 import UpperBarConfig = KalturaPlayerContribTypes.UpperBarConfig;
 import {getContribConfig} from './contrib-utils';
 import {IconsMenu} from './components/icons-menu';
+
+const DefaultPluginOrder = {
+  Navigation: 10,
+  'Q&A': 20,
+  Moderation: 30,
+  Transcript: 40,
+  'Download transcript': 50,
+  Share: 70,
+  Playlist: 80,
+  Info: 90,
+  Related: 100,
+  Quiz: 110,
+  Layout: 120,
+  'Source Selector': 140,
+  Polls: 150,
+};
+
 const {
   components: {PLAYER_SIZE},
 } = KalturaPlayer.ui;
@@ -45,19 +62,10 @@ export class UpperBarManager {
   constructor(options: UpperBarManagerOptions) {
     this._options = options;
 
-    this._upperBarConfig = getContribConfig(
-      this._options.kalturaPlayer,
-      'ui.upperBar',
-      defaultUpperBarConfig,
-      {
-        explicitMerge: ['presetAreasMapping'],
-      }
-    );
-    this._iconsMenuConfig = getContribConfig(
-      this._options.kalturaPlayer,
-      'ui.iconsMenu',
-      {iconsOrder: {}}
-    );
+    this._upperBarConfig = getContribConfig(this._options.kalturaPlayer, 'ui.upperBar', defaultUpperBarConfig, {
+      explicitMerge: ['presetAreasMapping'],
+    });
+    this._iconsMenuConfig = getContribConfig(this._options.kalturaPlayer, 'ui.iconsMenu', {iconsOrder: {}});
 
     const groupedPresets = PresetsUtils.groupPresetAreasByType({
       presetAreasMapping: this._upperBarConfig.presetAreasMapping,
@@ -84,9 +92,7 @@ export class UpperBarManager {
   };
 
   private _renderItems = (playerSize: string) => {
-    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(
-      playerSize
-    );
+    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(playerSize);
 
     const isIconMenuVisible = !!(upperBarItems.length && iconMenuItems.length);
 
@@ -126,13 +132,14 @@ export class UpperBarManager {
     //       }
     //     }
     // };
+    const undefinedPluginDefaultOrder = Math.max(...Object.values(DefaultPluginOrder)) + 10;
     const itemOptions = {
       kalturaPlayer: this._options.kalturaPlayer,
       data,
       order: ObjectUtils.get(
         this._iconsMenuConfig,
         `iconsOrder.${data.label}`,
-        0
+        DefaultPluginOrder[data.label] || undefinedPluginDefaultOrder
       ),
     };
     const item = new UpperBarItem(itemOptions);

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -132,14 +132,13 @@ export class UpperBarManager {
     //       }
     //     }
     // };
-    const undefinedPluginDefaultOrder = Infinity;
     const itemOptions = {
       kalturaPlayer: this._options.kalturaPlayer,
       data,
       order: ObjectUtils.get(
         this._iconsMenuConfig,
         `iconsOrder.${data.label}`,
-        DefaultPluginOrder[data.label] || undefinedPluginDefaultOrder
+        DefaultPluginOrder[data.label] || Infinity
       ),
     };
     const item = new UpperBarItem(itemOptions);

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -62,10 +62,19 @@ export class UpperBarManager {
   constructor(options: UpperBarManagerOptions) {
     this._options = options;
 
-    this._upperBarConfig = getContribConfig(this._options.kalturaPlayer, 'ui.upperBar', defaultUpperBarConfig, {
-      explicitMerge: ['presetAreasMapping'],
-    });
-    this._iconsMenuConfig = getContribConfig(this._options.kalturaPlayer, 'ui.iconsMenu', {iconsOrder: {}});
+    this._upperBarConfig = getContribConfig(
+      this._options.kalturaPlayer,
+      'ui.upperBar',
+      defaultUpperBarConfig,
+      {
+        explicitMerge: ['presetAreasMapping'],
+      }
+    );
+    this._iconsMenuConfig = getContribConfig(
+      this._options.kalturaPlayer,
+      'ui.iconsMenu',
+      {iconsOrder: {}}
+    );
 
     const groupedPresets = PresetsUtils.groupPresetAreasByType({
       presetAreasMapping: this._upperBarConfig.presetAreasMapping,
@@ -92,7 +101,9 @@ export class UpperBarManager {
   };
 
   private _renderItems = (playerSize: string) => {
-    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(playerSize);
+    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(
+      playerSize
+    );
 
     const isIconMenuVisible = !!(upperBarItems.length && iconMenuItems.length);
 

--- a/packages/ui/src/upper-bar-manager.tsx
+++ b/packages/ui/src/upper-bar-manager.tsx
@@ -62,19 +62,10 @@ export class UpperBarManager {
   constructor(options: UpperBarManagerOptions) {
     this._options = options;
 
-    this._upperBarConfig = getContribConfig(
-      this._options.kalturaPlayer,
-      'ui.upperBar',
-      defaultUpperBarConfig,
-      {
-        explicitMerge: ['presetAreasMapping'],
-      }
-    );
-    this._iconsMenuConfig = getContribConfig(
-      this._options.kalturaPlayer,
-      'ui.iconsMenu',
-      {iconsOrder: {}}
-    );
+    this._upperBarConfig = getContribConfig(this._options.kalturaPlayer, 'ui.upperBar', defaultUpperBarConfig, {
+      explicitMerge: ['presetAreasMapping'],
+    });
+    this._iconsMenuConfig = getContribConfig(this._options.kalturaPlayer, 'ui.iconsMenu', {iconsOrder: {}});
 
     const groupedPresets = PresetsUtils.groupPresetAreasByType({
       presetAreasMapping: this._upperBarConfig.presetAreasMapping,
@@ -101,9 +92,7 @@ export class UpperBarManager {
   };
 
   private _renderItems = (playerSize: string) => {
-    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(
-      playerSize
-    );
+    const {upperBarItems, iconMenuItems} = this._prepareUpperBarItems(playerSize);
 
     const isIconMenuVisible = !!(upperBarItems.length && iconMenuItems.length);
 
@@ -143,8 +132,7 @@ export class UpperBarManager {
     //       }
     //     }
     // };
-    const undefinedPluginDefaultOrder: number =
-      Math.max(...Object.values(DefaultPluginOrder)) + 10;
+    const undefinedPluginDefaultOrder = Infinity;
     const itemOptions = {
       kalturaPlayer: this._options.kalturaPlayer,
       data,


### PR DESCRIPTION
### Description of the Changes

solve the problem of asynchrony between icons managed in the contrib and those managed directly with the player
and add default plugins order logic

Solves FEV-413

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated